### PR TITLE
Added dynamic led gpio device

### DIFF
--- a/customleds.tcsh
+++ b/customleds.tcsh
@@ -9,11 +9,16 @@
 # based on gwstatus, set color of first LED
 # circle    square    diamond
 # led 2  -  led 1  -  led 0
-# 6 7 8  -  3 4 5  -  0 1 2 
+# 6 7 8  -  3 4 5  -  0 1 2
 #
 # mvneta0 is OPT
 # mvneta1 is LAN
 # mvneta2 is WAN
+
+# gpio device number
+# A way to get the gpio device that controls the led lights (its not always 0)
+set gdev = `sysctl dev.gpio | grep .led. | cut -d . -f 3 | uniq`
+
 
 # Some constants
 set if = ${1}
@@ -31,13 +36,13 @@ case "mvneta0":
     set ping = 1
     set pinb = 2
     breaksw
-case "mvneta1": 
+case "mvneta1":
     set lednum = 1
     set pinr = 3
     set ping = 4
     set pinb = 5
     breaksw
-case "mvneta2": 
+case "mvneta2":
     set lednum = 2
     set pinr = 6
     set ping = 7
@@ -47,12 +52,12 @@ endsw
 
 
 # disable dark time between light bursts
-/sbin/sysctl dev.gpio.0.pin.$pinr.T0=0
-/sbin/sysctl dev.gpio.0.pin.$pinr.T4=0
-/sbin/sysctl dev.gpio.0.pin.$ping.T0=0
-/sbin/sysctl dev.gpio.0.pin.$ping.T4=0
-/sbin/sysctl dev.gpio.0.pin.$pinb.T0=0
-/sbin/sysctl dev.gpio.0.pin.$pinb.T4=0
+/sbin/sysctl dev.gpio.$gdev.pin.$pinr.T0=0
+/sbin/sysctl dev.gpio.$gdev.pin.$pinr.T4=0
+/sbin/sysctl dev.gpio.$gdev.pin.$ping.T0=0
+/sbin/sysctl dev.gpio.$gdev.pin.$ping.T4=0
+/sbin/sysctl dev.gpio.$gdev.pin.$pinb.T0=0
+/sbin/sysctl dev.gpio.$gdev.pin.$pinb.T4=0
 
 
 
@@ -80,95 +85,94 @@ set sum = `netstat -w 60 -I $if -q 1 | tail -1 | awk '{ ORS="  "; print $4 }' `
 
 switch ($gwstatus)
 case "none":
-case "Online": 
+case "Online":
 
     ### The WAN is up, set the color to bandwidth usage
     if ($sum <= $l1) then
         echo no traffic, led dark
-        /sbin/sysctl dev.gpio.0.led.$lednum.pwm=1
-        /usr/sbin/gpioctl $pinr duty 4
-        /usr/sbin/gpioctl $ping duty 4
-        /usr/sbin/gpioctl $pinb duty 4
+        /sbin/sysctl dev.gpio.$gdev.led.$lednum.pwm=1
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinr duty 4
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $ping duty 4
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinb duty 4
 
     else if ($sum <= $l2) then
         echo low traffic, led solid green
-        /sbin/sysctl dev.gpio.0.led.$lednum.pwm=1
-        /usr/sbin/gpioctl $pinr duty 0
-        /usr/sbin/gpioctl $ping duty 32
-        /usr/sbin/gpioctl $pinb duty 0
+        /sbin/sysctl dev.gpio.$gdev.led.$lednum.pwm=1
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinr duty 0
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $ping duty 32
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinb duty 0
 
     else if ($sum <= $l3) then
         echo medium traffic, led solid blue
-        /sbin/sysctl dev.gpio.0.led.$lednum.pwm=1
-        /usr/sbin/gpioctl $pinr duty 0
-        /usr/sbin/gpioctl $ping duty 0
-        /usr/sbin/gpioctl $pinb duty 32
+        /sbin/sysctl dev.gpio.$gdev.led.$lednum.pwm=1
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinr duty 0
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $ping duty 0
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinb duty 32
 
     else if ($sum <= $l4) then
         echo medium-high traffic, led slow flashing purple
-        /sbin/sysctl dev.gpio.0.led.$lednum.pwm=0
-        /sbin/sysctl dev.gpio.0.led.$lednum.T2=1040
-        /sbin/sysctl dev.gpio.0.led.$lednum.T1-T3=520
-        /usr/sbin/gpioctl $pinr duty 32
-        /usr/sbin/gpioctl $ping duty 0
-        /usr/sbin/gpioctl $pinb duty 32
+        /sbin/sysctl dev.gpio.$gdev.led.$lednum.pwm=0
+        /sbin/sysctl dev.gpio.$gdev.led.$lednum.T2=1040
+        /sbin/sysctl dev.gpio.$gdev.led.$lednum.T1-T3=520
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinr duty 32
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $ping duty 0
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinb duty 32
 
     else if ($sum <= $l5) then
         echo high traffic, led fast flashing bright purple
         # Fast flashing purple
-        /sbin/sysctl dev.gpio.0.led.$lednum.pwm=0
-        /sbin/sysctl dev.gpio.0.led.$lednum.T2=0
-        /sbin/sysctl dev.gpio.0.led.$lednum.T1-T3=520
-        /usr/sbin/gpioctl $pinr duty 128
-        /usr/sbin/gpioctl $ping duty 0
-        /usr/sbin/gpioctl $pinb duty 128
+        /sbin/sysctl dev.gpio.$gdev.led.$lednum.pwm=0
+        /sbin/sysctl dev.gpio.$gdev.led.$lednum.T2=0
+        /sbin/sysctl dev.gpio.$gdev.led.$lednum.T1-T3=520
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinr duty 128
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $ping duty 0
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinb duty 128
 
     else
         echo very high traffic, led fast flashing bright orange
-        /sbin/sysctl dev.gpio.0.led.$lednum.pwm=0
-        /sbin/sysctl dev.gpio.0.led.$lednum.T2=0
-        /sbin/sysctl dev.gpio.0.led.$lednum.T1-T3=520
-        /usr/sbin/gpioctl $pinr duty 128
-        /usr/sbin/gpioctl $ping duty 8
-        /usr/sbin/gpioctl $pinb duty 0
+        /sbin/sysctl dev.gpio.$gdev.led.$lednum.pwm=0
+        /sbin/sysctl dev.gpio.$gdev.led.$lednum.T2=0
+        /sbin/sysctl dev.gpio.$gdev.led.$lednum.T1-T3=520
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinr duty 128
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $ping duty 8
+        /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinb duty 0
     endif
     breaksw
 
 
 
-case "down": 
+case "down":
 case "Offline":
     echo link down, led red
-    /sbin/sysctl dev.gpio.0.led.$lednum.pwm=0
-    /sbin/sysctl dev.gpio.0.led.$lednum.T2=520
-    /sbin/sysctl dev.gpio.0.led.$lednum.T1-T3=520
-    /usr/sbin/gpioctl $pinr duty 128
-    /usr/sbin/gpioctl $ping duty 0
-    /usr/sbin/gpioctl $pinb duty 0
+    /sbin/sysctl dev.gpio.$gdev.led.$lednum.pwm=0
+    /sbin/sysctl dev.gpio.$gdev.led.$lednum.T2=520
+    /sbin/sysctl dev.gpio.$gdev.led.$lednum.T1-T3=520
+    /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinr duty 128
+    /usr/sbin/gpioctl -f /dev/gpioc$gdev $ping duty 0
+    /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinb duty 0
     breaksw
 
 case "highloss":
-case "loss": 
+case "loss":
 case "highdelay":
 case "delay":
-case "Warning": 
+case "Warning":
     echo link decay, led yellow
-    /sbin/sysctl dev.gpio.0.led.$lednum.pwm=0
-    /sbin/sysctl dev.gpio.0.led.$lednum.T2=520
-    /sbin/sysctl dev.gpio.0.led.$lednum.T1-T3=520
-    /usr/sbin/gpioctl $pinr duty 128
-    /usr/sbin/gpioctl $ping duty 32
-    /usr/sbin/gpioctl $pinb duty 0
+    /sbin/sysctl dev.gpio.$gdev.led.$lednum.pwm=0
+    /sbin/sysctl dev.gpio.$gdev.led.$lednum.T2=520
+    /sbin/sysctl dev.gpio.$gdev.led.$lednum.T1-T3=520
+    /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinr duty 128
+    /usr/sbin/gpioctl -f /dev/gpioc$gdev $ping duty 32
+    /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinb duty 0
     breaksw
 
 default:
     echo link state unknown, led white
-    /sbin/sysctl dev.gpio.0.led.$lednum.pwm=0
-    /sbin/sysctl dev.gpio.0.led.$lednum.T2=520
-    /sbin/sysctl dev.gpio.0.led.$lednum.T1-T3=520
-    /usr/sbin/gpioctl $pinr duty 128
-    /usr/sbin/gpioctl $ping duty 128
-    /usr/sbin/gpioctl $pinb duty 128
+    /sbin/sysctl dev.gpio.$gdev.led.$lednum.pwm=0
+    /sbin/sysctl dev.gpio.$gdev.led.$lednum.T2=520
+    /sbin/sysctl dev.gpio.$gdev.led.$lednum.T1-T3=520
+    /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinr duty 128
+    /usr/sbin/gpioctl -f /dev/gpioc$gdev $ping duty 128
+    /usr/sbin/gpioctl -f /dev/gpioc$gdev $pinb duty 128
 
-endsw
-
+Endsw


### PR DESCRIPTION
The default device is /dev/gpioc0, and the OID dev.gpio.0.* matches that; however, it is not always guaranteed. I just added a variable to hold the correct device number.  Mine changed from 2.4.5 to 2.5.0-dev.

See this post for more info: https://forum.netgate.com/topic/155553/sg-3100-leds-not-switching

Cool script by the way. (Also, just noticed it appears my editor added some rogue spaces, feel free to ignore those)